### PR TITLE
Rename exported function to match rollup plugin (tacit) naming convention

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { CompilerOptions, findConfigFile, nodeModuleNameResolver, sys } from 'typescript';
 
-export const resolveTypescriptPaths = ({
+export const typescriptPaths = ({
 	tsConfigPath = findConfigFile('./', sys.fileExists),
 	absolute = true,
 	transform,

--- a/readme.md
+++ b/readme.md
@@ -40,12 +40,12 @@ npm install --save-dev rollup-plugin-typescript-paths
 ## Usage
 
 ```js
-import { resolveTypescriptPaths } from 'rollup-plugin-typescript-paths';
+import { typescriptPaths } from 'rollup-plugin-typescript-paths';
 
 export default {
   // ...
   plugins: [
-    resolveTypescriptPaths()
+    typescriptPaths()
   ]
 }
 ```

--- a/test/index.js
+++ b/test/index.js
@@ -2,13 +2,13 @@
 
 const { strictEqual } = require('assert');
 const { resolve, join } = require('path');
-const { resolveTypescriptPaths } = require('../dist');
+const { typescriptPaths } = require('../dist');
 
 const transform = path => path.replace(/\.js$/i, '.cjs.js');
 
-const plugin = resolveTypescriptPaths({ tsConfigPath: resolve(__dirname, 'tsconfig.json') });
-const pluginNonAbs = resolveTypescriptPaths({ tsConfigPath: resolve(__dirname, 'tsconfig.json'), absolute: false });
-const pluginTransform = resolveTypescriptPaths({ tsConfigPath: resolve(__dirname, 'tsconfig.json'), transform });
+const plugin = typescriptPaths({ tsConfigPath: resolve(__dirname, 'tsconfig.json') });
+const pluginNonAbs = typescriptPaths({ tsConfigPath: resolve(__dirname, 'tsconfig.json'), absolute: false });
+const pluginTransform = typescriptPaths({ tsConfigPath: resolve(__dirname, 'tsconfig.json'), transform });
 
 try {
 	strictEqual(plugin.resolveId('@asdf', ''), null);


### PR DESCRIPTION
Almost every rollup plugin exports a function whose name is a camel-cased version of the package name without the `rollup-plugin-` (or `@rollup/plugin-`) prefix. Since rollup-plugin-typescript-paths uses a named export, I cannot rename it without using the `as` keyword, and it kind of stands out among the other plugins:

```javascript
import autoExternal from 'rollup-plugin-auto-external'
import nodeResolve from '@rollup/plugin-node-resolve'
import commonjs from '@rollup/plugin-commonjs'
import cleaner from 'rollup-plugin-cleaner'
import serve from 'rollup-plugin-serve'
import html from '@rollup/plugin-html'
import ts from 'rollup-plugin-ts'
import { resolveTypescriptPaths as typescriptPaths } from 'rollup-plugin-typescript-paths'
import { terser } from 'rollup-plugin-terser'
import { eslint } from 'rollup-plugin-eslint'
```

I know this pr is quite incidental, but would you consider it ?