### PR TITLE
feat: resolve paths from extended tsconfig files

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ const transform = path => path.replace(/\.js$/i, '.cjs.js');
 const plugin = typescriptPaths({ tsConfigPath: resolve(__dirname, 'tsconfig.json') });
 const pluginNonAbs = typescriptPaths({ tsConfigPath: resolve(__dirname, 'tsconfig.json'), absolute: false });
 const pluginTransform = typescriptPaths({ tsConfigPath: resolve(__dirname, 'tsconfig.json'), transform });
+const pluginExtended = typescriptPaths({ tsConfigPath: resolve(__dirname, 'tsconfig.extended.json') });
 
 try {
 	strictEqual(plugin.resolveId('@asdf', ''), null);
@@ -20,6 +21,8 @@ try {
 	strictEqual(pluginNonAbs.resolveId('@foobar', ''), join('test', 'foo', 'bar.js'));
 
 	strictEqual(pluginTransform.resolveId('@foobar', ''), join(__dirname, 'foo', 'bar.cjs.js'));
+
+	strictEqual(pluginExtended.resolveId('@foobar', ''), join(__dirname, 'foo', 'bar.js'));
 	console.log('PASSED');
 } catch (error) {
 	throw error;

--- a/test/tsconfig.extended.json
+++ b/test/tsconfig.extended.json
@@ -1,0 +1,3 @@
+{
+	extends: "./tsconfig.json"
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"baseUrl": "test",
+		"baseUrl": "",
 		"paths": {
 			"@foobar": ["foo/bar"],
 			"@bar/*": ["bar/*"],


### PR DESCRIPTION
With this PR module resolution also works if the path mapping is defined in a tsconfig file that is extended by the given tsconfig.