### PR TITLE
feat: escape $ and ^ characters from path

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,9 @@ export const typescriptPaths = ({
 			const hasMatchingPath =
 				!!compilerOptions.paths &&
 				Object.keys(compilerOptions.paths).some((path) =>
-					new RegExp('^' + path.replace('*', '.+') + '$').test(importee),
+					new RegExp('^' + escapeRegex(path.replace('*', '.+')) + '$').test(
+						importee,
+					),
 				);
 
 			if (!hasMatchingPath && !nonRelative) {
@@ -95,6 +97,14 @@ const getTsConfig = (configPath?: string): TsConfig => {
 	const { config } = parseConfigFileTextToJson(configPath, configJson);
 
 	return { ...defaults, ...config };
+};
+
+/**
+ * Escapes $ and ^ characters in the given string. This is necessary if you
+ * want to use `$/*` in your paths, for example.
+ */
+const escapeRegex = (str: string) => {
+	return str.replace(/[$^]/g, '\\$&');
 };
 
 export interface Options {

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,12 @@ try {
 		join(__dirname, 'bar', 'foo.js'),
 	);
 
+	// resolves $/* paths
+	strictEqual(
+		plugin.resolveId('$/foo/bar', ''),
+		join(__dirname, 'foo', 'bar.js'),
+	);
+
 	// resolves from a directory with index file
 	strictEqual(plugin.resolveId('@js', ''), join(__dirname, 'js', 'index.js'));
 

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -7,7 +7,8 @@
 			"@foobar-react": ["foo/bar-react"],
 			"@bar/*": ["bar/*"],
 			"bar/*": ["bar/*"],
-			"@js": ["js"]
+			"@js": ["js"],
+			"$/*": ["*"]
 		}
 	}
 }


### PR DESCRIPTION
I have a use-case where we specify the `$/*` path in the tsconfig, but it didn't work with this plugin because the `$` character wasn't escaped.